### PR TITLE
Require python3.6.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 py_modules = pygments_pre_commit
 install_requires =
     pygments
-python_requires = >=3.6
+python_requires = >=3.6.1
 
 [options.entry_points]
 pygments.lexers =


### PR DESCRIPTION
[python 3 statement - 3.6.0](https://github.com/asottile/scratch/wiki/python-3-statement#360)

(due to broken `NamedTuple` in 3.6.0)

Committed via https://github.com/asottile/all-repos