### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,12 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38]
+    toxenvs: [py37, py38]
     os: linux

--- a/pygments_pre_commit.py
+++ b/pygments_pre_commit.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 import os.path
 import re
 from typing import Any
-from typing import Dict
-from typing import Optional
 
 import pygments.lexer
 import pygments.token
@@ -52,7 +52,7 @@ STYLESHEET = '''\
 '''
 
 
-def stylesheet(colors: Optional[Dict[str, str]] = None) -> str:
+def stylesheet(colors: dict[str, str] | None = None) -> str:
     colors = colors or {}
     assert set(colors) <= set(COLORS), set(colors) - set(COLORS)
     colors = dict(COLORS, **colors)
@@ -60,7 +60,7 @@ def stylesheet(colors: Optional[Dict[str, str]] = None) -> str:
 
 
 def setup(app: Any) -> None:  # pragma: no cover (sphinx)
-    def copy_stylesheet(app: Any, exception: Optional[BaseException]) -> None:
+    def copy_stylesheet(app: Any, exception: BaseException | None) -> None:
         if exception:
             return
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,7 +24,7 @@ classifiers =
 py_modules = pygments_pre_commit
 install_requires =
     pygments
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.entry_points]
 pygments.lexers =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/testing/make-index
+++ b/testing/make-index
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import os
 
 HTML = '''\

--- a/tests/pygments_pre_commit_test.py
+++ b/tests/pygments_pre_commit_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os.path
 import re
 import subprocess

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pre-commit
+envlist = py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos